### PR TITLE
Update Dockerfile.armv7

### DIFF
--- a/Dockerfile.armv7
+++ b/Dockerfile.armv7
@@ -197,7 +197,7 @@ RUN ./contrib/download-frozen-image.sh /docker-frozen-images \
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone -b v1.0.3 https://github.com/cpuguy83/go-md2man.git "$GOPATH/src/github.com/cpuguy83/go-md2man" \
-	&& git clone -b v1.2 https://github.com/russross/blackfriday.git "$GOPATH/src/github.com/russross/blackfriday" \
+	&& git clone -b v1.4 https://github.com/russross/blackfriday.git "$GOPATH/src/github.com/russross/blackfriday" \
 	&& go get -v -d github.com/cpuguy83/go-md2man \
 	&& go build -v -o /usr/local/bin/go-md2man github.com/cpuguy83/go-md2man \
 	&& rm -rf "$GOPATH"


### PR DESCRIPTION
Google has moved its code.google... code base which has broken this Dockerfile right at line 200.  After digging, I discovered that the version v1.2 of https://github.com/russross/blackfriday.git has fixed this in later versions.  Therefore this release needs to be updated to the latest which is v1.4.
